### PR TITLE
Integrated minicrypt initial files in the areg project. 

### DIFF
--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -1212,7 +1212,8 @@ function(printAregConfigStatus var_make_print var_prefix var_header var_footer)
     message(STATUS "${var_prefix}: >>> Build Modules ......: areg = '${AREG_BINARY}', aregextend = static, areglogger = '${AREG_LOGGER_BINARY}', executable extension '${CMAKE_EXECUTABLE_SUFFIX}'")
     message(STATUS "${var_prefix}: >>> Java Version .......: '${Java_VERSION_STRING}', Java executable = '${Java_JAVA_EXECUTABLE}', minimum version required = 17")
     message(STATUS "${var_prefix}: >>> Packages Use .......: SQLite3 package use = '${AREG_SQLITE_PACKAGE}', GTest package use = '${AREG_GTEST_PACKAGE}'")
-    message(STATUS "${var_prefix}: >>> Other Options ......: Examples = '${AREG_BUILD_EXAMPLES}', Unit Tests = '${AREG_BUILD_TESTS}', AREG Extended = '${AREG_EXTENDED}', Logs = '${AREG_LOGS}'")
+    message(STATUS "${var_prefix}: >>> Modules enabled ....: Logs = '${AREG_LOGS}', Crypto = '${AREG_CRYPTO}'")
+    message(STATUS "${var_prefix}: >>> Other Options ......: Examples = '${AREG_BUILD_EXAMPLES}', Unit Tests = '${AREG_BUILD_TESTS}', AREG Extended = '${AREG_EXTENDED}'")
     message(STATUS "${var_prefix}: >>> Installation .......: Enabled = '${AREG_INSTALL}', location = '${CMAKE_INSTALL_PREFIX}'")
 
     # Print the footer section with separators

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -19,17 +19,18 @@
 #   9. AREG_BUILD_EXAMPLES  -- Enables or disables building examples for the AREG Framework.
 #  10. AREG_EXTENDED        -- Enables or disables extended AREG Framework features. May require additional dependencies.
 #  11. AREG_LOGS            -- Enables or disables logging during compilation. Defaults to 'enabled'.
-#  12. AREG_USE_PACKAGES    -- Enables or disables using installed packages. Controls other package options like SQLite and GTest.
-#  13. AREG_SQLITE_PACKAGE  -- Determines if the system's SQLite3 package should be used or compiled from source.
-#  14. AREG_GTEST_PACKAGE   -- Determines if the system's GTest package should be used or compiled from source.
-#  15. AREG_ENABLE_OUTPUTS  -- If disabled, output directories will match the CMake binary directory.
-#  16. AREG_BUILD_ROOT      -- Specifies the root directory for build files. Defaults to './product' within the AREG SDK root.
-#  17. AREG_OUTPUT_DIR      -- Directory where build outputs are placed.
-#  18. AREG_OUTPUT_BIN      -- Directory for output binaries (executables and shared libraries).
-#  19. AREG_OUTPUT_LIB      -- Directory for output static libraries.
-#  20. AREG_PACKAGES        -- Location for fetching third-party packages such as GTest.
-#  21. AREG_INSTALL         -- Enables or disables installation of AREG SDK binaries, headers and dependencies like 'sqlite3' and 'ncurses'.
-#  22. AREG_INSTALL_PATH    -- Location where AREG SDK binaries, headers, and tools are installed. Defaults to the user's home directory.
+#  12. AREG_CRYPTO          -- Enables or disables cryptography during compilation. Defaults to 'enabled'.
+#  13. AREG_USE_PACKAGES    -- Enables or disables using installed packages. Controls other package options like SQLite and GTest.
+#  14. AREG_SQLITE_PACKAGE  -- Determines if the system's SQLite3 package should be used or compiled from source.
+#  15. AREG_GTEST_PACKAGE   -- Determines if the system's GTest package should be used or compiled from source.
+#  16. AREG_ENABLE_OUTPUTS  -- If disabled, output directories will match the CMake binary directory.
+#  17. AREG_BUILD_ROOT      -- Specifies the root directory for build files. Defaults to './product' within the AREG SDK root.
+#  18. AREG_OUTPUT_DIR      -- Directory where build outputs are placed.
+#  19. AREG_OUTPUT_BIN      -- Directory for output binaries (executables and shared libraries).
+#  20. AREG_OUTPUT_LIB      -- Directory for output static libraries.
+#  21. AREG_PACKAGES        -- Location for fetching third-party packages such as GTest.
+#  22. AREG_INSTALL         -- Enables or disables installation of AREG SDK binaries, headers and dependencies like 'sqlite3' and 'ncurses'.
+#  23. AREG_INSTALL_PATH    -- Location where AREG SDK binaries, headers, and tools are installed. Defaults to the user's home directory.
 #
 # Default Values:
 #   1. AREG_COMPILER_FAMILY = <default> (possible values: gnu, cygwin, mingw, llvm, msvc)
@@ -43,17 +44,18 @@
 #   9. AREG_BUILD_EXAMPLES  = ON        (possible values: ON, OFF)
 #  10. AREG_EXTENDED        = OFF       (possible values: ON, OFF)
 #  11. AREG_LOGS            = ON        (possible values: ON, OFF)
-#  12. AREG_USE_PACKAGES    = ON        (possible values: ON, OFF)
-#  13. AREG_SQLITE_PACKAGE  = ON        (possible values: ON, OFF)
-#  14. AREG_GTEST_PACKAGE   = ON        (possible values: ON, OFF)
-#  15. AREG_ENABLE_OUTPUTS  = ON        (possible values: ON, OFF)
-#  16. AREG_BUILD_ROOT      = '<areg-sdk>/product'    (path for output and generated files)
-#  17. AREG_OUTPUT_DIR      = '<areg-sdk>/product/build/<default-compiler family-name>/<os>-<bitness>-<cpu>-release-<areg-lib>'
-#  18. AREG_OUTPUT_BIN      = '<areg-sdk>/product/build/<default-compiler family-name>/<os>-<bitness>-<cpu>-release-<areg-lib>/bin'
-#  19. AREG_OUTPUT_LIB      = '<areg-sdk>/product/build/<default-compiler family-name>/<os>-<bitness>-<cpu>-release-<areg-lib>/lib'
-#  20. AREG_PACKAGES        = '${CMAKE_BINARY_DIR}/packages'
-#  21. AREG_INSTALL         = ON        (possible values: ON, OFF)
-#  22. AREG_INSTALL_PATH    = '${HOME}/areg-sdk' (or '${USERPROFILE}' on Windows, defaults to current directory if unset)
+#  12. AREG_CRYPTO          = ON        (possible values: ON, OFF)
+#  13. AREG_USE_PACKAGES    = ON        (possible values: ON, OFF)
+#  14. AREG_SQLITE_PACKAGE  = ON        (possible values: ON, OFF)
+#  15. AREG_GTEST_PACKAGE   = ON        (possible values: ON, OFF)
+#  16. AREG_ENABLE_OUTPUTS  = ON        (possible values: ON, OFF)
+#  17. AREG_BUILD_ROOT      = '<areg-sdk>/product'    (path for output and generated files)
+#  18. AREG_OUTPUT_DIR      = '<areg-sdk>/product/build/<default-compiler family-name>/<os>-<bitness>-<cpu>-release-<areg-lib>'
+#  19. AREG_OUTPUT_BIN      = '<areg-sdk>/product/build/<default-compiler family-name>/<os>-<bitness>-<cpu>-release-<areg-lib>/bin'
+#  20. AREG_OUTPUT_LIB      = '<areg-sdk>/product/build/<default-compiler family-name>/<os>-<bitness>-<cpu>-release-<areg-lib>/lib'
+#  21. AREG_PACKAGES        = '${CMAKE_BINARY_DIR}/packages'
+#  22. AREG_INSTALL         = ON        (possible values: ON, OFF)
+#  23. AREG_INSTALL_PATH    = '${HOME}/areg-sdk' (or '${USERPROFILE}' on Windows, defaults to current directory if unset)
 #
 # Hints:
 #   - AREG_COMPILER_FAMILY is an easy way to set compilers:
@@ -260,6 +262,9 @@ macro_create_option(AREG_EXTENDED OFF "Enable extended feature")
 
 # Modify 'AREG_LOGS' to enable or disable compilation with logs. By default, compile with logs
 macro_create_option(AREG_LOGS ON "Compile with logs")
+
+# Modify 'AREG_CRYPTO' to enable or disable compilation with cryptographic module. By default, compile with crypto
+macro_create_option(AREG_CRYPTO ON "Compile with cryptography")
 
 # Modify 'AREG_INSTALL' to enable or disable installation of AREG SDK
 macro_create_option(AREG_INSTALL ON "Enable installation")

--- a/conf/msvc/user.props
+++ b/conf/msvc/user.props
@@ -53,9 +53,10 @@
         <!-- ****************************************************************************************************************************** -->
         <!-- Add preprocessor defines here to set for all projects.                                                                         -->
         <!-- ****************************************************************************************************************************** -->
-        <!-- AREG_LOGS 	        : enable compilation with logging; remove if no logging required.                                           -->
+        <!-- AREG_LOGS 	        : enable or disable compilation with logging module of Areg library; remove if no logging required.         -->
         <!-- AREG_EXTENDED      : enable or disable extensions in AREG extended static library, which contain additional features.          -->
-        <AregCommonDefines>AREG_LOGS=$(AregLogs);AREG_EXTENDED=$(AregExtended);$(AregCommonDefines)</AregCommonDefines>
+        <!-- AREG_CRYPTO        : enable or disable compilation with crypto module of Areg library; remove is no crypto required.           -->
+        <AregCommonDefines>AREG_LOGS=$(AregLogs);AREG_EXTENDED=$(AregExtended);AREG_CRYPTO=$(AregCrypto);$(AregCommonDefines)</AregCommonDefines>
 
         <!-- ****************************************************************************************************************************** -->
         <!-- Advanced settings do not change or modify.                                                                                     -->

--- a/framework/areg.vcxproj
+++ b/framework/areg.vcxproj
@@ -110,6 +110,11 @@
     <ClCompile Include="areg\base\private\NEDebug.cpp" />
     <ClCompile Include="areg\base\private\NEMemory.cpp" />
     <ClCompile Include="areg\base\private\NEUtilities.cpp" />
+    <ClCompile Include="areg\crypto\private\MCHelper.cpp" />
+    <ClCompile Include="areg\crypto\private\MCMd5.cpp" />
+    <ClCompile Include="areg\crypto\private\MCRandom.cpp" />
+    <ClCompile Include="areg\crypto\private\MCSha1.cpp" />
+    <ClCompile Include="areg\crypto\private\MCSha256.cpp" />
     <ClCompile Include="areg\ipc\private\IEServiceConnectionConsumer.cpp" />
     <ClCompile Include="areg\ipc\private\IEServiceRegisterProvider.cpp" />
     <ClCompile Include="areg\component\private\ServiceManagerEventProcessor.cpp" />
@@ -251,6 +256,11 @@
     <ClInclude Include="areg\base\TEString.hpp" />
     <ClInclude Include="areg\base\TEValue.hpp" />
     <ClInclude Include="areg\base\WideString.hpp" />
+    <ClInclude Include="areg\crypto\private\MCHelper.hpp" />
+    <ClInclude Include="areg\crypto\private\MCMd5.hpp" />
+    <ClInclude Include="areg\crypto\private\MCRandom.hpp" />
+    <ClInclude Include="areg\crypto\private\MCSha1.hpp" />
+    <ClInclude Include="areg\crypto\private\MCSha256.hpp" />
     <ClInclude Include="areg\ipc\IEServiceConnectionConsumer.hpp" />
     <ClInclude Include="areg\ipc\IEServiceRegisterProvider.hpp" />
     <ClInclude Include="areg\component\private\ClientInfo.hpp" />
@@ -428,6 +438,7 @@
     <Text Include="areg\component\private\CMakeLists.txt" />
     <Text Include="areg\component\private\posix\CMakeLists.txt" />
     <Text Include="areg\component\private\win32\CMakeLists.txt" />
+    <Text Include="areg\crypto\private\CMakeLists.txt" />
     <Text Include="areg\ipc\private\CMakeLists.txt" />
     <Text Include="areg\persist\private\CMakeLists.txt" />
     <Text Include="areg\logging\private\CMakeLists.txt" />

--- a/framework/areg.vcxproj.filters
+++ b/framework/areg.vcxproj.filters
@@ -570,6 +570,21 @@
     <ClCompile Include="areg\logging\private\IELogDatabaseEngine.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="areg\crypto\private\MCHelper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="areg\crypto\private\MCRandom.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="areg\crypto\private\MCSha256.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="areg\crypto\private\MCSha1.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="areg\crypto\private\MCMd5.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="areg\system\windows\GEWindows.h">
@@ -1133,6 +1148,21 @@
     <ClInclude Include="areg\resources\resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="areg\crypto\private\MCHelper.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="areg\crypto\private\MCRandom.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="areg\crypto\private\MCSha256.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="areg\crypto\private\MCSha1.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="areg\crypto\private\MCMd5.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="areg\resources\areg.rc">
@@ -1187,5 +1217,6 @@
     <Text Include="areg\component\private\win32\CMakeLists.txt">
       <Filter>Resource Files</Filter>
     </Text>
+    <Text Include="areg\crypto\private\CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/framework/areg/crypto/private/MCHelper.cpp
+++ b/framework/areg/crypto/private/MCHelper.cpp
@@ -6,7 +6,7 @@
  * You should have received a copy of the AREG SDK license description in LICENSE.txt.
  * If not, please contact to info[at]aregtech.com
  *
- * \file        areg/logging/private/Layouts.cpp
+ * \file        areg/crypto/private/MCHelper.cpp
  * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
  * \author      David Sugar
  * \brief       Helper functions for Minicrypt back-end
@@ -14,7 +14,7 @@
 
 #if AREG_CRYPTO
 
-#include "MCHelper.hpp"
+#include "areg/crypto/private/MCHelper.hpp"
 
 //////////////////////////////////////////////////////////////////////////
 // A non-cacheable memory clean function

--- a/framework/areg/crypto/private/MCHelper.hpp
+++ b/framework/areg/crypto/private/MCHelper.hpp
@@ -6,7 +6,7 @@
  * You should have received a copy of the AREG SDK license description in LICENSE.txt.
  * If not, please contact to info[at]aregtech.com
  *
- * \file        areg/logging/private/Layouts.cpp
+ * \file        areg/crypto/private/MCHelper.hpp
  * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
  * \author      David Sugar
  * \brief       Helper functions for Minicrypt back-end

--- a/framework/areg/crypto/private/MCMd5.cpp
+++ b/framework/areg/crypto/private/MCMd5.cpp
@@ -6,7 +6,7 @@
  * You should have received a copy of the AREG SDK license description in LICENSE.txt.
  * If not, please contact to info[at]aregtech.com
  *
- * \file        areg/logging/private/Layouts.cpp
+ * \file        areg/crypto/private/MCMd5.cpp
  * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
  * \author      David Sugar
  * \brief       MD5 Hash Digest functions
@@ -14,8 +14,8 @@
 
 #if AREG_CRYPTO
 
-#include "MCMd5.hpp"
-#include "MCHelper.hpp"
+#include "areg/crypto/private/MCMd5.hpp"
+#include "areg/crypto/private/MCHelper.hpp"
 #include <cstring>
 
 namespace {
@@ -230,7 +230,7 @@ int MiniCrypt::md5_digest(const void *data, std::size_t size, uint8_t *out, cons
     md5_init(ctx);
     if (salt)
         md5_update(ctx, salt, 16);
-    md5_update(ctx, static_cast<const uint8_t*>(data), size);
+    md5_update(ctx, static_cast<const uint8_t*>(data), static_cast<uint32_t>(size));
     return md5_final(ctx, out);
 }
 

--- a/framework/areg/crypto/private/MCMd5.hpp
+++ b/framework/areg/crypto/private/MCMd5.hpp
@@ -6,7 +6,7 @@
  * You should have received a copy of the AREG SDK license description in LICENSE.txt.
  * If not, please contact to info[at]aregtech.com
  *
- * \file        areg/logging/private/Layouts.cpp
+ * \file        areg/crypto/private/MCMd5.hpp
  * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
  * \author      David Sugar
  * \brief       MD5 MD5 Digest functions

--- a/framework/areg/crypto/private/MCRandom.hpp
+++ b/framework/areg/crypto/private/MCRandom.hpp
@@ -6,7 +6,7 @@
  * You should have received a copy of the AREG SDK license description in LICENSE.txt.
  * If not, please contact to info[at]aregtech.com
  *
- * \file        areg/logging/private/Layouts.cpp
+ * \file        areg/crypto/private/MCRandom.hpp
  * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
  * \author      David Sugar
  * \brief       Generate cryptographic random values
@@ -17,6 +17,7 @@
 
 #if AREG_CRYPTO
 
+#include <cstddef>
 #include <cstdint>
 #ifdef _MSC_VER
 #include <BaseTsd.h>

--- a/framework/areg/crypto/private/MCSha1.cpp
+++ b/framework/areg/crypto/private/MCSha1.cpp
@@ -6,7 +6,7 @@
  * You should have received a copy of the AREG SDK license description in LICENSE.txt.
  * If not, please contact to info[at]aregtech.com
  *
- * \file        areg/logging/private/Layouts.cpp
+ * \file        areg/crypto/private/MCSha1.cpp
  * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
  * \author      David Sugar
  * \brief       Sha1 Hash Digest functions
@@ -14,8 +14,8 @@
 
 #if AREG_CRYPTO
 
-#include "MCSha1.hpp"
-#include "MCHelper.hpp"
+#include "areg/crypto/private/MCSha1.hpp"
+#include "areg/crypto/private/MCHelper.hpp"
 #include <cstring>
 
 namespace {

--- a/framework/areg/crypto/private/MCSha1.hpp
+++ b/framework/areg/crypto/private/MCSha1.hpp
@@ -6,7 +6,7 @@
  * You should have received a copy of the AREG SDK license description in LICENSE.txt.
  * If not, please contact to info[at]aregtech.com
  *
- * \file        areg/logging/private/Layouts.cpp
+ * \file        areg/crypto/private/MCSha1.hpp
  * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
  * \author      David Sugar
  * \brief       Sha1 Hash Digest functions

--- a/framework/areg/crypto/private/MCSha256.cpp
+++ b/framework/areg/crypto/private/MCSha256.cpp
@@ -6,7 +6,7 @@
  * You should have received a copy of the AREG SDK license description in LICENSE.txt.
  * If not, please contact to info[at]aregtech.com
  *
- * \file        areg/logging/private/Layouts.cpp
+ * \file        areg/crypto/private/MCSha256.cpp
  * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
  * \author      David Sugar
  * \brief       Sha256 Hash Digest functions
@@ -14,8 +14,8 @@
 
 #if AREG_CRYPTO
 
-#include "MCSha256.hpp"
-#include "MCHelper.hpp"
+#include "areg/crypto/private/MCSha256.hpp"
+#include "areg/crypto/private/MCHelper.hpp"
 #include <cstring>
 
 namespace {

--- a/framework/areg/crypto/private/MCSha256.hpp
+++ b/framework/areg/crypto/private/MCSha256.hpp
@@ -6,7 +6,7 @@
  * You should have received a copy of the AREG SDK license description in LICENSE.txt.
  * If not, please contact to info[at]aregtech.com
  *
- * \file        areg/logging/private/Layouts.cpp
+ * \file        areg/crypto/private/MCSha256.hpp
  * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
  * \author      David Sugar
  * \brief       Sha256 Hash Digest functions

--- a/msvc_setup.props
+++ b/msvc_setup.props
@@ -80,6 +80,11 @@
         <!-- ********************************************************************************************************************************** -->
         <AregLogs>1</AregLogs>
         <!-- ********************************************************************************************************************************** -->
+        <!-- Property to compile the source codes with enabled crypto. By default, the sources are compiled with crypto.                        -->
+        <!-- Set 0 to compile sources codes without crypto. Set 1 or ignore setting to compile with crypto enabled.                             -->
+        <!-- ********************************************************************************************************************************** -->
+        <AregCrypto>1</AregCrypto>
+        <!-- ********************************************************************************************************************************** -->
         <!-- Add Build type specific preprocessor defines here for Debug and Release to set for all projects.                                   -->
         <!-- If use in other projects, set following preprocessor definitions:                                                                  -->
         <!--   * IMP_AREG_DLL to import objects from areg.dll and IMP_AREG_LIB to import objects from AREG static library.                      -->
@@ -131,6 +136,9 @@
         </BuildMacro>
         <BuildMacro Include="AregLogs">
             <Value>$(AregLogs)</Value>
+        </BuildMacro>
+        <BuildMacro Include="AregCrypto">
+            <Value>$(AregCrypto)</Value>
         </BuildMacro>
         <BuildMacro Include="AregCommonDefines">
             <Value>$(AregCommonDefines)</Value>


### PR DESCRIPTION
Changes done:
1. Integrated minicrypt files into areg project of MSVC;
2. Changed the property files of MSVS to be able to compile areg with/without crypto using MSBuild;
3. Changed `user.cmake` to enable crypto by default;
4. Slight change to output crypto message on console;
5. Fixed warnings and errors when build under Windows and Ubuntu.

@dyfet , please review and merge.