### PR TITLE
Start of crypto areg public crypto framework with a Helper

### DIFF
--- a/framework/areg/crypto/private/CMakeLists.txt
+++ b/framework/areg/crypto/private/CMakeLists.txt
@@ -4,5 +4,6 @@ macro_add_source(areg_SRC "${AREG_FRAMEWORK}"
     areg/crypto/private/MCSha256.cpp
     areg/crypto/private/MCHmac.cpp
     areg/crypto/private/MCAes.cpp
+    areg/crypto/private/CryptoHelper.cpp
 )
 

--- a/framework/areg/crypto/private/CryptoHelper.cpp
+++ b/framework/areg/crypto/private/CryptoHelper.cpp
@@ -1,0 +1,31 @@
+/************************************************************************
+ * This file is part of the AREG SDK core engine.
+ * AREG SDK is dual-licensed under Free open source (Apache version 2.0
+ * License) and Commercial (with various pricing models) licenses, depending
+ * on the nature of the project (commercial, research, academic or free).
+ * You should have received a copy of the AREG SDK license description in LICENSE.txt.
+ * If not, please contact to info[at]aregtech.com
+ *
+ * \file        areg/crypto/private/CryptoHelper.cpp
+ * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
+ * \author      David Sugar
+ * \brief       Helper functions conversions, used by public headers
+ ************************************************************************/
+
+#if AREG_CRYPTO
+
+#include "areg/crypto/private/CryptoHelper.hpp"
+
+auto NECrypto::EncodeHex(std::string_view input) noexcept -> std::string {
+    constexpr char hex[] = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(input.size() * 2);
+    for (const auto& b : input) {
+        auto val = uint8_t(b);
+        out.push_back(hex[val >> 4]);
+        out.push_back(hex[val & 0x0f]);
+    }
+    return out;
+}
+
+#endif

--- a/framework/areg/crypto/private/CryptoHelper.hpp
+++ b/framework/areg/crypto/private/CryptoHelper.hpp
@@ -1,0 +1,78 @@
+/************************************************************************
+ * This file is part of the AREG SDK core engine.
+ * AREG SDK is dual-licensed under Free open source (Apache version 2.0
+ * License) and Commercial (with various pricing models) licenses, depending
+ * on the nature of the project (commercial, research, academic or free).
+ * You should have received a copy of the AREG SDK license description in LICENSE.txt.
+ * If not, please contact to info[at]aregtech.com
+ *
+ * \file        areg/crypto/private/CryptoHelper.hpp
+ * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
+ * \author      David Sugar
+ * \brief       Crypto helper functions for backend glueing and secure arrays
+ ************************************************************************/
+
+#ifndef AREG_CRYPTO_PRIVATE_CRYPTOHELPER_HPP
+#define AREG_CRYPTO_PRIVATE_CRYPTOHELPER_HPP
+
+#if AREG_CRYPTO
+#include "areg/base/GEGlobal.h"
+
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+namespace NECrypto {
+constexpr auto ToByte(std::byte b) noexcept {
+    return static_cast<uint8_t>(b);
+}
+
+constexpr auto ToByte(uint8_t u) noexcept {
+    return static_cast<std::byte>(u);
+}
+
+constexpr auto ToByte(char u) noexcept {
+    return static_cast<std::byte>(u);
+}
+
+static inline auto ToBytes(const uint8_t *data) noexcept {
+    return reinterpret_cast<const std::byte *>(data);
+}
+
+static inline auto ToBytes(uint8_t *data) noexcept {
+    return reinterpret_cast<std::byte *>(data);
+}
+
+static inline auto ToBytes(const char *data) noexcept {
+    return reinterpret_cast<const uint8_t *>(data);
+}
+
+static inline auto ToBytes(char *data) noexcept {
+    return reinterpret_cast<uint8_t *>(data);
+}
+
+static inline auto ToBytes(const std::byte *data) noexcept {
+    return reinterpret_cast<const uint8_t *>(data);
+}
+
+static inline auto ToBytes(std::byte *data) noexcept {
+    return reinterpret_cast<uint8_t *>(data);
+}
+
+auto EncodeHex(std::string_view input) noexcept -> std::string;
+
+template <typename T>
+inline auto ToStringView(const T& obj) -> std::string_view {
+    return std::string_view(reinterpret_cast<const char *>(obj.data()), obj.size
+());
+}
+
+template <typename Binary>
+inline auto ToHex(const Binary& bin) {
+    return EncodeHex(ToStringView(bin));
+}
+} // end namespace
+#endif
+#endif
+


### PR DESCRIPTION
This is to help set the pattern and conventions for the remaining crypto framework work. I used the file naming based on logger events. I am not sure of CryptoHelper.hpp should be more public facing rather that in private/, as it may have some useful utility functions that might be directly used by someone and will be included by other public facing headers. Feel free to fix naming conventions, etc. Its a simple start for the rest, but it at least gets something to start from for the mainline code @aregtech 


