### PR TITLE
Initial crypto fontend with minicrypt backend

### DIFF
--- a/framework/areg/crypto/Crypto.hpp
+++ b/framework/areg/crypto/Crypto.hpp
@@ -1,0 +1,77 @@
+/************************************************************************
+ * This file is part of the AREG SDK core engine.
+ * AREG SDK is dual-licensed under Free open source (Apache version 2.0
+ * License) and Commercial (with various pricing models) licenses, depending
+ * on the nature of the project (commercial, research, academic or free).
+ * You should have received a copy of the AREG SDK license description in LICENSE.txt.
+ * If not, please contact to info[at]aregtech.com
+ *
+ * \file        areg/crypto/Crypto.hpp
+ * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
+ * \author      David Sugar
+ * \brief       Selects crypto backnd and provides basic types, common code
+ ************************************************************************/
+
+#ifndef AREG_CRYPTO_CRYPTO_HPP
+#define AREG_CRYPTO_CRYPTO_HPP
+
+#if AREG_CRYPTO
+
+#include "areg/crypto/TESecureArray.hpp"
+#include "areg/crypto/private/CryptoHelper.hpp"
+
+namespace NECrypto {
+using Salt = TESecureArray<8>;
+using Sha256 = TESecureArray<32>;
+using Sha512 = TESecureArray<64>;
+}
+
+// Selects backend header library based on defines...
+#if AREG_CRYPTO_OPENSSL
+#include "areg/crypto/private/CeyptoOpenssl.hpp"
+#elif AREG_CRYPTO_SODIUM
+#include "areg/crypto/private/CeyptoSodium.hpp"
+#else
+#include "areg/crypto/private/CryptoMinicrypt.hpp"
+#endif
+
+// common functionms that depend on a backend...
+
+namespace NECrypto {
+template <std::size_t S>
+auto RandomKey(TESecureArray<S>& key) {
+    RandomContext rng;
+    return key.fill(rng.fill(key));
+}
+
+template <typename KEY>
+bool RandomKey(KEY& key) {
+    RandomContext rng;
+    key.clear();
+    return key.fill(rng.fill(key));
+}
+
+Salt MakeSalt() {
+    Salt salt;
+    RandomContext rng;
+    salt.fill(rng.fill(salt));
+    return salt;
+}
+
+template <typename BINARY, typename DIGEST = Sha256>
+uint64_t ToU64(const BINARY& input) {
+    DIGEST digest;
+    static_assert(digest.size() >= sizeof(uint64_t));
+    if (!init_digest(digest, input)) return static_cast<uint64_t>(-1);
+    uint64_t out{0};
+    const auto bin = digest.ToBytes();
+    for (std::size_t i = 0; i < sizeof(out); ++i) {
+        out = (out << 8) | static_cast<uint8_t>(bin[i]);
+    }
+    return out;
+}
+}
+
+#endif
+#endif
+

--- a/framework/areg/crypto/private/CryptoHelper.cpp
+++ b/framework/areg/crypto/private/CryptoHelper.cpp
@@ -33,5 +33,5 @@ auto NECrypto::EncodeHex(std::string_view input) noexcept -> std::string {
 // WARNING: THIS IS TEMPORARY CODE TO HELP TESTING BUILD OF HEADER ONLY
 // COMPONENTS THAT HAVE NO BUILDS YET.  REMOVE WHEN NO LONGER NEEDED>
 
-#include "areg/crypto/TESecureArray.hpp"
+#include "areg/crypto/Crypto.hpp"
 

--- a/framework/areg/crypto/private/CryptoMinicrypt.hpp
+++ b/framework/areg/crypto/private/CryptoMinicrypt.hpp
@@ -1,0 +1,73 @@
+/************************************************************************
+ * This file is part of the AREG SDK core engine.
+ * AREG SDK is dual-licensed under Free open source (Apache version 2.0
+ * License) and Commercial (with various pricing models) licenses, depending
+ * on the nature of the project (commercial, research, academic or free).
+ * You should have received a copy of the AREG SDK license description in LICENSE.txt.
+ * If not, please contact to info[at]aregtech.com
+ *
+ * \file        areg/crypto/private/CryptoMinicrypt.hpp
+ * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
+ * \author      David Sugar
+ * \brief       Crypto backend for Minicrypt operations
+ ************************************************************************/
+
+#ifndef AREG_CRYPTO_PRIVATE_CRYPTOMINICRYPT_HPP
+#define AREG_CRYPTO_PRIVATE_CRYPTOMINICRYPT_HPP
+
+#if AREG_CRYPTO
+#include "areg/crypto/TESecureArray.hpp"
+#include "areg/crypto/private/CryptoHelper.hpp"
+#include "areg/crypto/private/MCHelper.hpp"
+#include "areg/crypto/private/MCSha256.hpp"
+#include "areg/crypto/private/MCRandom.hpp"
+#include "areg/crypto/private/MCHmac.hpp"
+
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+namespace NECrypto {
+class RandomContext final {
+public:
+    RandomContext() { MiniCrypt::random_init(_rng); }
+    ~RandomContext() { MiniCrypt::random_free(_rng); }
+    RandomContext(const RandomContext&) = delete;
+    RandomContext& operator=(const RandomContext&) = delete;
+
+    template <typename BINARY>
+    inline bool fill(BINARY& buf) {
+        auto const put = ToBytes(buf.data());
+        auto len = MiniCrypt::random_fill(_rng, put, buf.size());
+        return len == ssize_t(buf.size());
+    }
+
+private:
+    MiniCrypt::random_ctx _rng;
+};
+
+template <typename BINARY>
+bool HashDigest(Sha256& out, const BINARY& input, Salt& salt = Salt()) {
+    MiniCrypt::sha256_ctx ctx;
+    auto const get = ToBytes(input.data());
+    auto const sp = ToBytes(salt.data());
+    auto put = ToBytes(out.data());
+    MiniCrypt::sha256_init(ctx);
+    if (!salt.empty()) MiniCrypt::sha256_update(ctx, sp, salt.size());
+    MiniCrypt::sha256_update(ctx, get, input.size());
+    MiniCrypt::sha256_final(ctx, put);
+    return out.fill();
+}
+
+template <typename KEY, typename BINARY = KEY>
+bool HmacDigest(Sha256& out, const KEY& key, const BINARY& input) {
+    auto const get = ToBytes(input.data());
+    auto const kv = ToBytes(key.data());
+    auto put = ToBytes(out.data());
+    MiniCrypt::hmac256(kv, key.size(), get, input.size(), put);
+    return out.fill();
+}
+} // end namespace
+#endif
+#endif


### PR DESCRIPTION
This represents how I am thinking of connecting crypto backends to frontends for Areg crypto. For example, there would also be a Digest.hpp / private/DigestXxx.hpp for digest streams, and Ciperh.hpp / private/CypherXxx.hpp for ciphers.

@aregtech 