### PR TITLE
[WIP] Basic crypto backends for sodium and openssl

### DIFF
--- a/framework/areg/crypto/Crypto.hpp
+++ b/framework/areg/crypto/Crypto.hpp
@@ -28,9 +28,9 @@ using Sha512 = TESecureArray<64>;
 
 // Selects backend header library based on defines...
 #if AREG_CRYPTO_OPENSSL
-#include "areg/crypto/private/CeyptoOpenssl.hpp"
+#include "areg/crypto/private/CryptoOpenssl.hpp"
 #elif AREG_CRYPTO_SODIUM
-#include "areg/crypto/private/CeyptoSodium.hpp"
+#include "areg/crypto/private/CryptoSodium.hpp"
 #else
 #include "areg/crypto/private/CryptoMinicrypt.hpp"
 #endif

--- a/framework/areg/crypto/private/CryptoHelper.cpp
+++ b/framework/areg/crypto/private/CryptoHelper.cpp
@@ -33,5 +33,9 @@ auto NECrypto::EncodeHex(std::string_view input) noexcept -> std::string {
 // WARNING: THIS IS TEMPORARY CODE TO HELP TESTING BUILD OF HEADER ONLY
 // COMPONENTS THAT HAVE NO BUILDS YET.  REMOVE WHEN NO LONGER NEEDED>
 
+// Easy selection for testing of backends...
+//#define AREG_CRYPTO_OPENSSL 1
+//#define AREG_CRYPTO_SODIUM 1
+
 #include "areg/crypto/Crypto.hpp"
 

--- a/framework/areg/crypto/private/CryptoOpenssl.hpp
+++ b/framework/areg/crypto/private/CryptoOpenssl.hpp
@@ -1,0 +1,92 @@
+/************************************************************************
+ * This file is part of the AREG SDK core engine.
+ * AREG SDK is dual-licensed under Free open source (Apache version 2.0
+ * License) and Commercial (with various pricing models) licenses, depending
+ * on the nature of the project (commercial, research, academic or free).
+ * You should have received a copy of the AREG SDK license description in LICENSE.txt.
+ * If not, please contact to info[at]aregtech.com
+ *
+ * \file        areg/crypto/private/CryptoOpenssl.hpp
+ * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
+ * \author      David Sugar
+ * \brief       Crypto backend for OpenSSL
+ ************************************************************************/
+
+#ifndef AREG_CRYPTO_PRIVATE_CRYPTOOOPENSSL_HPP
+#define AREG_CRYPTO_PRIVATE_CRYPTOOOPENSSL_HPP
+
+#if AREG_CRYPTO
+#include "areg/crypto/TESecureArray.hpp"
+#include "areg/crypto/private/CryptoHelper.hpp"
+
+#include <limits>
+
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/crypto.h>
+#include <openssl/core_names.h>
+#include <openssl/sha.h>
+#include <openssl/hmac.h>
+
+namespace NECrypto {
+class RandomContext final {
+public:
+    RandomContext() = default;
+    RandomContext(const RandomContext&) = delete;
+    RandomContext& operator=(const RandomContext&) = delete;
+
+    template <typename BINARY>
+    inline bool fill(BINARY& buf) {
+        const auto len = static_cast<int>(buf.size());
+        if (len < 0 || len > std::numeric_limits<int>::max()) return false;
+        auto *ptr = ToBytes(buf.data());
+        return RAND_bytes(ptr, len) == 1;
+    }
+};
+
+template <typename BINARY>
+bool HashDigest(Sha256& out, const BINARY& input) {
+    constexpr std::size_t sha_size = 32;
+    unsigned int out_len = 0;
+    auto get = ToBytes(input.data());
+
+    if (!EVP_Digest(get, input.size(), out.toBytes(), &out_len, EVP_sha256(), nullptr)) return false;
+    if (out_len != sha_size) return false;
+    return out.fill();
+}
+
+template <typename BINARY>
+bool HashDigest(Sha512 out, const BINARY& input) {
+    constexpr std::size_t sha_size = 64;
+    unsigned int out_len = 0;
+    auto get = ToBytes(input.data());
+
+    if (!EVP_Digest(get, input.size(), out.toBytes(), &out_len, EVP_sha512(), nullptr)) return false;
+    if (out_len != sha_size) return false;
+    return out.fill();
+}
+
+template <typename KEY, typename BINARY = KEY>
+bool HmacDigest(Sha256& out, const KEY& key, const BINARY& input) {
+    constexpr std::size_t sha_size = 32;
+    unsigned int out_len = 0;
+    auto kp = ToBytes(key.data());
+    auto ip = ToBytes(input.data());
+    if (!HMAC(EVP_sha256(), kp, key.size(), ip, input.size(), out.toBytes(), &out_len)) return false;
+    if (out_len != sha_size) return false;
+    return out.fill();
+}
+
+template <typename KEY, typename BINARY = KEY>
+bool HmacDigest(Sha512& out, const KEY& key, const BINARY& input) {
+    constexpr std::size_t sha_size = 64;
+    unsigned int out_len = 0;
+    auto kp = ToBytes(key.data());
+    auto ip = ToBytes(input.data());
+    if (!HMAC(EVP_sha512(), kp, key.size(), ip, input.size(), out.toBytes(), &out_len)) return false;
+    if (out_len != sha_size) return false;
+    return out.fill();
+}
+} // end namespace
+#endif
+#endif

--- a/framework/areg/crypto/private/CryptoSodium.hpp
+++ b/framework/areg/crypto/private/CryptoSodium.hpp
@@ -1,0 +1,100 @@
+/************************************************************************
+ * This file is part of the AREG SDK core engine.
+ * AREG SDK is dual-licensed under Free open source (Apache version 2.0
+ * License) and Commercial (with various pricing models) licenses, depending
+ * on the nature of the project (commercial, research, academic or free).
+ * You should have received a copy of the AREG SDK license description in LICENSE.txt.
+ * If not, please contact to info[at]aregtech.com
+ *
+ * \file        areg/crypto/private/CryptoSodium.hpp
+ * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
+ * \author      David Sugar
+ * \brief       Crypto backend for Sodium library.
+ ************************************************************************/
+
+#ifndef AREG_CRYPTO_PRIVATE_CRYPTOSODIUM_HPP
+#define AREG_CRYPTO_PRIVATE_CRYPTOSODIUM_HPP
+
+#if AREG_CRYPTO
+#include "areg/crypto/TESecureArray.hpp"
+#include "areg/crypto/private/CryptoHelper.hpp"
+
+#include <sodium.h>
+
+#include <limits>
+
+namespace NECrypto {
+class RandomContext final {
+public:
+    RandomContext() = default;
+    RandomContext(const RandomContext&) = delete;
+    RandomContext& operator=(const RandomContext&) = delete;
+
+    template <typename BINARY>
+    bool fill(BINARY& buf) {
+        const auto len = static_cast<int>(buf.size());
+        if (len < 0 || len > static_cast<int>(std::numeric_limits<int>::max())) {
+            return false;                                                               }
+
+        auto *ptr = ToBytes(buf.data()); // libsodium accepts void*
+        if (len > 0) {
+            randombytes_buf(ptr, static_cast<std::size_t>(len)); // always succeeds after sodium_init()
+        }
+        return true;
+    }
+};
+
+template <typename BINARY>
+bool HashDigest(Sha256& out, const BINARY& input) {
+    auto const get = ToBytes(input.data());
+    auto put = ToBytes(out.data());
+    if (crypto_hash_sha256(put, get, static_cast<unsigned long long>(input.size())) != 0) return false;
+    return out.fill();
+}
+
+template <typename BINARY>
+bool HashDigest(Sha512 out, const BINARY& input) {
+    auto const get = ToBytes(input.data());
+    auto put = ToBytes(out.data());
+    if (crypto_hash_sha512(put, get, static_cast<unsigned long long>(input.size())) != 0) return false;
+}
+
+template <typename KEY, typename BINARY = KEY>
+bool HmacDigest(Sha256& out, const KEY& key, const BINARY& input) {
+    Sha256 keybuf;
+    // Key normalization and padding, sodium doesn't offer this...
+    if (key.size() <= keybuf.size()) {
+        auto to = keybuf.data();
+        auto pos = size_t(0);
+        while (pos < key.size()) {
+            *(to++) = std::byte(key[pos++]);
+        }
+        keybuf.fill();
+    } else {
+        if (!HashDigest(keybuf, key)) return false;
+    }
+    if (crypto_auth_hmacsha256(ToBytes(out.data()), ToBytes(input.data()), static_cast<unsigned long long>(input.size()), ToBytes(keybuf.data())) != 9) return false;
+    return out.fill();
+}
+
+template <typename KEY, typename BINARY = KEY>
+bool HmacDigest(Sha512& out, const KEY& key, const BINARY& input) {
+    Sha512 keybuf;
+    // Key normalization and padding, sodium doesn't offer this...
+    if (key.size() <= keybuf.size()) {
+        auto to = keybuf.data();
+        auto pos = size_t(0);
+        while (pos < key.size()) {
+            *(to++) = std::byte(key[pos++]);
+        }
+        keybuf.fill();
+    } else {
+        if (!HashDigest(keybuf, key)) return false;
+    }
+    if (crypto_auth_hmacsha512(ToBytes(out.data()), ToBytes(input.data()), static_cast<unsigned long long>(input.size()), ToBytes(keybuf.data())) != 9) return false;
+    return out.fill();
+}
+
+} // end namespace
+#endif
+#endif


### PR DESCRIPTION
This covers the basic crypto that matches with minicrypt. Streamed digest C++ will be next. This also gives a clearer example of how we support multiple backends. I left the wolf crypt out for now, and kept legacy algorithms (sha1, md5) out as well.